### PR TITLE
Update compute_vector_decl.hpp

### DIFF
--- a/glm/detail/compute_vector_decl.hpp
+++ b/glm/detail/compute_vector_decl.hpp
@@ -160,7 +160,7 @@ namespace glm {
 			{
 				bool b = true;
 				for (length_t i = 0; i < L; ++i)
-					b = b && detail::compute_equal<T, std::numeric_limits<T>::is_iec559>::call(v1.x, v2.x);
+					b = b && detail::compute_equal<T, std::numeric_limits<T>::is_iec559>::call(v1[i], v2[i]);
 				return b;
 			}
 		};


### PR DESCRIPTION
Fix elementwise equality check in compute_vec_equal

Previously, the equality operator compared only the first element (v1.x and v2.x) repeatedly for all components. This commit updates the loop to use the index operator (v1[i] and v2[i]) so that every corresponding element is compared correctly.